### PR TITLE
Make `curl-sys` depend on `openssl-sys` for `aarch64-unknown-linux-gnu` triple as well

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -29,6 +29,8 @@ openssl-sys = "0.2.0"
 openssl-sys = "0.2.0"
 [target.arm-unknown-linux-gnueabihf.dependencies]
 openssl-sys = "0.2.0"
+[target.aarch64-unknown-linux-gnu.dependencies]
+openssl-sys = "0.2.0"
 [target.i686-unknown-freebsd.dependencies]
 openssl-sys = "0.2.0"
 [target.x86_64-unknown-freebsd.dependencies]


### PR DESCRIPTION
As https://github.com/rust-lang/rust/pull/19790 is hopefully landing soon, but https://github.com/rust-lang/cargo/issues/1007 is still open, it would be good to add this dependency. (Now, cargo builds need manual touchups after pulls.)