### PR TITLE
fix broken formatting of resp body and headers in the example of readme....

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pub fn main() {
     .get("http://www.example.com")
     .exec().unwrap();
 
-  println!("code={}; headers={}; body={}",
+  println!("code={}; headers={:?}; body={:?}",
     resp.get_code(), resp.get_headers(), resp.get_body());
 }
 ```


### PR DESCRIPTION
...md

Was not able to use the example without this fix. Might be useful to update for new users.