### PR TITLE
Implement Debug for http::response

### DIFF
--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 
 pub type Headers = HashMap<String, Vec<String>>;
 
+#[derive(Debug)]
 pub struct Response {
     code: u32,
     hdrs: Headers,


### PR DESCRIPTION
All types should implement Debug where possible.