### PR TITLE
Fix building on OpenBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ openssl-sys = "0.6.0"
 openssl-sys = "0.6.0"
 [target.x86_64-unknown-bitrig.dependencies]
 openssl-sys = "0.6.0"
+[target.x86_64-unknown-openbsd.dependencies]
+openssl-sys = "0.6.0"
 
 [[test]]
 

--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -38,3 +38,5 @@ openssl-sys = "0.6.0"
 openssl-sys = "0.6.0"
 [target.x86_64-unknown-bitrig.dependencies]
 openssl-sys = "0.6.0"
+[target.x86_64-unknown-openbsd.dependencies]
+openssl-sys = "0.6.0"


### PR DESCRIPTION
OpenBSD is very similar to bitrig, so I've just copied what's done for
bitrig and changed the arch triplet. I'm able to build on OpenBSD
-current (as of 2015-07-11) with this patch.