### PR TITLE
Android support in Cargo.toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,13 @@ openssl-sys = "0.6.0"
 openssl-sys = "0.6.0"
 [target.i686-unknown-linux-gnu.dependencies]
 openssl-sys = "0.6.0"
+[target.i686-linux-android.dependencies]
+openssl-sys = "0.6.0"
 [target.x86_64-unknown-linux-gnu.dependencies]
 openssl-sys = "0.6.0"
 [target.arm-unknown-linux-gnueabihf.dependencies]
+openssl-sys = "0.6.0"
+[target.arm-linux-androideabi.dependencies]
 openssl-sys = "0.6.0"
 [target.aarch64-unknown-linux-gnu.dependencies]
 openssl-sys = "0.6.0"

--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -27,9 +27,13 @@ openssl-sys = "0.6.0"
 openssl-sys = "0.6.0"
 [target.i686-unknown-linux-gnu.dependencies]
 openssl-sys = "0.6.0"
+[target.i686-linux-android.dependencies]
+openssl-sys = "0.6.0"
 [target.x86_64-unknown-linux-gnu.dependencies]
 openssl-sys = "0.6.0"
 [target.arm-unknown-linux-gnueabihf.dependencies]
+openssl-sys = "0.6.0"
+[target.arm-linux-androideabi.dependencies]
 openssl-sys = "0.6.0"
 [target.aarch64-unknown-linux-gnu.dependencies]
 openssl-sys = "0.6.0"

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -4,6 +4,7 @@ extern crate gcc;
 use std::env;
 use std::ffi::OsString;
 use std::fs;
+use std::io::{stderr, Write};
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -30,7 +31,8 @@ fn main() {
     // Next, fall back and try to use pkg-config if its available.
     match pkg_config::find_library("libcurl") {
         Ok(..) => return,
-        Err(..) => {}
+        Err(e) => writeln!(&mut stderr(), "Couldn't find libcurl from \
+                           pkgconfig ({:?}), compiling it from source...", e).unwrap(),
     }
 
     println!("cargo:rustc-link-search={}/lib", dst.display());

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -4,7 +4,6 @@ extern crate gcc;
 use std::env;
 use std::ffi::OsString;
 use std::fs;
-use std::io::{stderr, Write};
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -31,8 +30,8 @@ fn main() {
     // Next, fall back and try to use pkg-config if its available.
     match pkg_config::find_library("libcurl") {
         Ok(..) => return,
-        Err(e) => writeln!(&mut stderr(), "Couldn't find libcurl from \
-                           pkgconfig ({:?}), compiling it from source...", e).unwrap(),
+        Err(e) => println!("Couldn't find libcurl from \
+                           pkgconfig ({:?}), compiling it from source...", e),
     }
 
     println!("cargo:rustc-link-search={}/lib", dst.display());


### PR DESCRIPTION
Previously the openssl dependencies were not declared for Android targets.

Also changed the cargo build scripts a bit to mention that we are trying to
compile libcurl from source. This can be helpful if the compilation fails
and the user wants to know why.

(Compiling libcurl from source didn't fail for me - I just wanted to use my prebuilt cross-compiled libcurl by setting PKG_CONFIG_PATH but I didn't know PKG_CONFIG_ALLOW_CROSS before..)