### PR TITLE
PowerPC Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ openssl-sys = "0.7.0"
 openssl-sys = "0.7.0"
 [target.aarch64-unknown-linux-gnu.dependencies]
 openssl-sys = "0.7.0"
+[target.powerpc-unknown-linux-gnu.dependencies]
+openssl-sys = "0.7.0"
 [target.powerpc64-unknown-linux-gnu.dependencies]
 openssl-sys = "0.7.0"
 [target.powerpc64le-unknown-linux-gnu.dependencies]

--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -35,6 +35,8 @@ openssl-sys = ">= 0"
 openssl-sys = ">= 0"
 [target.aarch64-unknown-linux-gnu.dependencies]
 openssl-sys = ">= 0"
+[target.powerpc-unknown-linux-gnu.dependencies]
+openssl-sys = ">= 0"
 [target.powerpc64-unknown-linux-gnu.dependencies]
 openssl-sys = ">= 0"
 [target.powerpc64le-unknown-linux-gnu.dependencies]


### PR DESCRIPTION
Add `powerpc-unknown-linux-gnu` to the list of supported triples. This is blocking a native cargo build for powerpc. That being said, I'm not sure if I need to do anything other than add this dependency.