### PR TITLE
Fix compilation error, resolve warnings

### DIFF
--- a/test/server.rs
+++ b/test/server.rs
@@ -5,6 +5,7 @@ use std::net::{TcpStream, TcpListener};
 use std::str;
 use std::sync::mpsc::{channel, Sender, Receiver};
 use std::thread;
+use std::time::Duration;
 
 use self::Op::{SendBytes, ReceiveBytes, Wait, Shutdown};
 
@@ -52,6 +53,7 @@ struct Handle {
 pub enum Op {
     SendBytes(&'static [u8]),
     ReceiveBytes(&'static [u8]),
+    #[allow(dead_code)]
     Wait(usize),
     Shutdown
 }
@@ -126,7 +128,7 @@ impl OpSequence {
                                 to_debug_str(&b), to_debug_str(&act)));
                     }
                 }
-                &Wait(ms) => thread::sleep_ms(ms as u32),
+                &Wait(ms) => thread::sleep(Duration::from_millis(ms as u64)),
                 &Shutdown => {
                     return Err("Shutdown must be sent on its own".to_string())
                 }

--- a/test/test_head.rs
+++ b/test/test_head.rs
@@ -20,7 +20,7 @@ pub fn test_simple_head() {
     let res = res.unwrap();
 
     assert!(res.get_code() == 200, "code is {}", res.get_code());
-    assert!(res.get_body() == []);
+    assert!(res.get_body().len() == 0);
     assert!(res.get_headers().len() == 1);
     assert!(res.get_header("content-length") == ["5".to_string()]);
 }


### PR DESCRIPTION
Failed build: https://travis-ci.org/carllerche/curl-rust/builds/118506514

The main issue:
```
test/test_head.rs:23:13: 23:33 error: unable to infer enough type information about `_`; type annotations or generic parameter binding required [E0282]
test/test_head.rs:23     assert!(res.get_body() == []);
                                 ^~~~~~~~~~~~~~~~~~~~
test/test_head.rs:23:5: 23:35 note: in this expansion of assert! (defined in <std macros>)
test/test_head.rs:23:13: 23:33 help: run `rustc --explain E0282` to see a detailed explanation
```