### PR TITLE
Upgrade to rust-url 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/carllerche/curl-rust"
 description = "Rust bindings to libcurl for making HTTP requests"
 
 [dependencies]
-url = "0.5.0"
+url = ">= 0.5, < 2.0"
 log = "0.3.0"
 libc = "0.2"
 curl-sys = { path = "curl-sys", version = "0.1.0" }


### PR DESCRIPTION
Since `Url` is (indirectly) part of the public API, I think this is a breaking change.

It would be possible to depend on `url = ">= 0.5, < 2.0"` (so that this wouldn’t be a breaking change) if `as_str` is reverted to `to_string`, but that would leave an unnecessary `String` allocation.

`test_proxy` fails for me locally with "Timeout was reached", but it also does on master.